### PR TITLE
Made the creation of the tray icon optional

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -247,7 +247,10 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     }
 
     private void createUI(Container pane) {
-        setupTrayIcon();
+        //If creating the tray icon fails, ignore it.
+        try {
+            setupTrayIcon();
+        } catch (Exception e) { }
 
         EmptyBorder emptyBorder = new EmptyBorder(5, 5, 5, 5);
         GridBagConstraints gbc = new GridBagConstraints();


### PR DESCRIPTION
This'll bypass problems with RipMe not being able to make its tray icon.